### PR TITLE
Change HTTPCommand timeout to 600 seconds.

### DIFF
--- a/APLSource/Main-1/GitHubReleaseUploadAsset-82049.aplf
+++ b/APLSource/Main-1/GitHubReleaseUploadAsset-82049.aplf
@@ -30,7 +30,7 @@
      http.Headers⍪←'Authorization'('token ',⍺.GitToken)
      http.Params←80 ⎕DR rawread ⍵
      http.Command←'POST'
-     http.WaitTime←200
+     http.WaitTime←600
      http.URL←¯13↓⍺.AssetsUploadURL
      http.URL,←'?name=',percentEncode∊1↓⎕NPARTS ⍵
      r←http.Run


### PR DESCRIPTION
Help prevent upload failures on slow connections.

#102 