### PR TITLE
Fix for GetCommandLineArgs dropping double quotes on paths.

### DIFF
--- a/APLSource/Main-1/ExecuteAPL-381.aplf
+++ b/APLSource/Main-1/ExecuteAPL-381.aplf
@@ -7,7 +7,7 @@
      ⍝ ← ←→ Exit Code, Session Output
      ⍺←''
      (x a)←2↑(⊆⍺),⊂'ShowStatusOnError=0 Dyalog_LineEditor_Mode=1'
-     cx aa←2↑(2 ⎕NQ'.' 'GetCommandLineArgs'),⊂''
+     cx aa←GetStartupEnvironmentVariables''
      in←∊(⊆⍵),¨⎕UCS 13
      _net←⎕NS''
      _net.⎕USING←{

--- a/APLSource/Main-1/GetStartupEnvironmentVariables-200409.aplf
+++ b/APLSource/Main-1/GetStartupEnvironmentVariables-200409.aplf
@@ -1,0 +1,7 @@
+ GetStartupEnvironmentVariables←{
+     ev←0⊃2 ⎕NQ'.' 'GetCommandLineArgs'
+     evl←2 ⎕NQ'.' 'GetCommandLine'
+     si←1+≢ev
+     si+←2×'"'=↑evl
+     ev(si↓evl)
+ }


### PR DESCRIPTION
#105 