### PR TITLE
Build failure notification improvements

### DIFF
--- a/APLSource/Main-1/BuildWorkspace-21.aplf
+++ b/APLSource/Main-1/BuildWorkspace-21.aplf
@@ -9,6 +9,9 @@
      ⍝ l,←⊂'rc em←',(q pf),' ⎕SE.Dado.BuildWorkspace_ ', qv
      l,←⊂'rc em←',(q pf),' (⎕NS ⎕SE.zApps.Dado.Dado).Main.BuildWorkspace_ ',q v
      l,←⊂'em'
-     l,←⊂'⎕OFF (10+rc)'
-     dx ExecuteAPL l
+     l,←⊂'⎕OFF (12+rc)'
+     _←dx ExecuteAPL l
+     p←(GetApplicationFolder ⍺),⍺._Name,'.dws'
+     ⎕NEXISTS p:_
+     746 ⎕SIGNAL'BuildWorkspace failed to generate .dws file.'
  }

--- a/APLSource/Main-1/ExecuteOnBuild-281.aplf
+++ b/APLSource/Main-1/ExecuteOnBuild-281.aplf
@@ -5,6 +5,6 @@
      l←⊂']Dado.Version'
      l,←⊂'rc em←',(q pf),' ⎕SE.Dado.##.ExecuteOnBuild_ ',q v
      l,←⊂'em'
-     l,←⊂'⎕OFF (10+rc)'
+     l,←⊂'⎕OFF (12+rc)'
      ExecuteAPL l
  }


### PR DESCRIPTION
#62 Start process exit codes with 12 not 10 per Dyalog documentation recommendation.
#64 Signal error on BuildWorkspace failure.